### PR TITLE
Remove CJS incompatible exports.

### DIFF
--- a/lib/siphash-double.js
+++ b/lib/siphash-double.js
@@ -175,4 +175,4 @@ var SipHashDouble = (function () {
         string_to_u8: string_to_u8
     };
 })();
-var module = module || {}, exports = module.exports = SipHashDouble;
+module.exports = SipHashDouble;

--- a/lib/siphash-double.ts
+++ b/lib/siphash-double.ts
@@ -205,5 +205,4 @@ const SipHashDouble = (() => {
     };
 })();
 
-var module = module || {},
-    exports = module.exports = SipHashDouble;
+module.exports = SipHashDouble;

--- a/lib/siphash.js
+++ b/lib/siphash.js
@@ -164,4 +164,4 @@ var SipHash = (function () {
         string_to_u8: string_to_u8
     };
 })();
-var module = module || {}, exports = module.exports = SipHash;
+module.exports = SipHash;

--- a/lib/siphash.ts
+++ b/lib/siphash.ts
@@ -194,5 +194,4 @@ const SipHash = (() => {
     };
 })();
 
-var module = module || {},
-    exports = module.exports = SipHash;
+module.exports = SipHash;

--- a/lib/siphash13-double.js
+++ b/lib/siphash13-double.js
@@ -171,4 +171,4 @@ var SipHash13Double = (function () {
         string_to_u8: string_to_u8
     };
 })();
-var module = module || {}, exports = module.exports = SipHash13Double;
+module.exports = SipHash13Double;

--- a/lib/siphash13-double.ts
+++ b/lib/siphash13-double.ts
@@ -201,5 +201,4 @@ const SipHash13Double = (() => {
     };
 })();
 
-var module = module || {},
-    exports = module.exports = SipHash13Double;
+module.exports = SipHash13Double;

--- a/lib/siphash13.js
+++ b/lib/siphash13.js
@@ -161,4 +161,4 @@ var SipHash13 = (function () {
         string_to_u8: string_to_u8
     };
 })();
-var module = module || {}, exports = module.exports = SipHash13;
+module.exports = SipHash13;

--- a/lib/siphash13.ts
+++ b/lib/siphash13.ts
@@ -191,5 +191,4 @@ const SipHash13 = (() => {
     };
 })();
 
-var module = module || {},
-    exports = module.exports = SipHash13;
+module.exports = SipHash13;


### PR DESCRIPTION
var module = module || {}, exports = 
causes cjs module importers to crash.

This fix changes nothing in node but will allow cjs to esm converters to function correctly allowing easy import into the browser